### PR TITLE
add unit test to check ValueError is raised when column names contain $$

### DIFF
--- a/gptables/test/test_gptable.py
+++ b/gptables/test/test_gptable.py
@@ -474,6 +474,22 @@ class TestAttrValidationGPTable:
             create_gptable_with_kwargs({"table": pd.DataFrame(columns=column_names)})
 
     @pytest.mark.parametrize(
+        "column_names",
+        [
+            ["columnA$$note$$", "columnB"],
+            ["columnA", "columnB$$note$$"],
+        ],
+    )
+    def test_column_names_with_note_markers_raise_value_error(
+        self, column_names, create_gptable_with_kwargs
+    ):
+        """
+        Test that GPTable rejects note markers embedded in column names.
+        """
+        with pytest.raises(ValueError, match="Notes inside column headers"):
+            create_gptable_with_kwargs({"table": pd.DataFrame(columns=column_names)})
+
+    @pytest.mark.parametrize(
         "column_names,expectation",
         [
             (["columnA", "columnB", "columnC"], does_not_raise()),


### PR DESCRIPTION
### Proposed Changes
  -

### Related Issues
  - Related to https://github.com/ONSdigital/gptables/issues/349


### Pre-requisites
This section may not be fully required if the branch is not merging into main.
Please indicate items that aren't necessary and why, with comments around incomplete checks.

- [ ] Version number has been incremented, according to [SemVer][semver]
- [ ] Changelog has been updated, listing changes to this version. Use the [keep a changelog][changelog] format
- [ ] New features are tested
- [ ] New features follow the Analysis Function Releasing statistics in spreadsheets [guidance][guidance]
- [ ] New features are documented using the [numpydoc][numpy-docstrings] docstring format
- [ ] Other relevant package documentation is updated
- [ ] For new functionality, examples are included in the docs or a [feature request][feature-request] has
been made for it/them
- [ ] Required workflows and pre-commits succeed

[changelog]: [https://keepachangelog.com/en/1.0.0/]
[feature-request]: [https://github.com/best-practice-and-impact/gptables/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=]
[guidance]: https://analysisfunction.civilservice.gov.uk/policy-store/releasing-statistics-in-spreadsheets/
[numpy-docstrings]: [https://numpydoc.readthedocs.io/en/latest/format.html]
[semver]: [https://semver.org/spec/v2.0.0.html]
