### PR TITLE
add benchmark_write_performance and implement efficiencies

### DIFF
--- a/gptables/core/wrappers.py
+++ b/gptables/core/wrappers.py
@@ -699,13 +699,16 @@ class GPWorksheet(Worksheet):
             raise ValueError("data and formats arrays must be of equal shape")
 
         rows, cols = data.shape
+
+        data_rows = data.values.tolist()
+        format_rows = formats.values.tolist()
         for row in range(rows):
             for col in range(cols):
-                cell_data = data.iloc[row, col]
-                cell_format_dict = formats.iloc[row, col]
-
                 self._smart_write(
-                    pos[0] + row, pos[1] + col, cell_data, cell_format_dict
+                    pos[0] + row,
+                    pos[1] + col,
+                    data_rows[row][col],
+                    format_rows[row][col],
                 )
 
         pos = [pos[0] + rows, 0]
@@ -948,12 +951,16 @@ class GPWorksheet(Worksheet):
         """
         cols = table.shape[1]
         col_widths = []
+
+        data_rows = table.values.tolist()
+        format_rows = formats_table.values.tolist()
+        num_rows = table.shape[0]
         for col in range(cols):
             cell_widths = []
-            for row in range(table.shape[0]):
-                cell_val = table.iloc[row, col]
+            for row in range(num_rows):
+                cell_val = data_rows[row][col]
                 longest_line = self._get_longest_line(cell_val)
-                format_dict = formats_table.iloc[row, col]
+                format_dict = format_rows[row][col]
                 scaling_factor = self._get_scaling_factor(format_dict, longest_line)
                 width = ceil(cell_autofit_width(longest_line) * scaling_factor)
                 cell_widths.append(width)
@@ -1005,11 +1012,21 @@ class GPWorkbook(Workbook):
     """
 
     def __init__(self, filename: str = None, options: dict = {}) -> None:
+        self._format_cache: dict = {}
         super(GPWorkbook, self).__init__(filename=filename, options=options)
         self.theme = None
         self._annotations = None
         # Set default theme
         self.set_theme(gptheme)
+
+    def add_format(self, properties: dict = None) -> object:
+        """Cache Format objects by their property dict to avoid redundant allocations."""
+        if properties is None:
+            properties = {}
+        key = tuple(sorted(properties.items()))
+        if key not in self._format_cache:
+            self._format_cache[key] = super().add_format(properties)
+        return self._format_cache[key]
 
     def add_worksheet(
         self, name: str = None, gridlines: str = "hide_all"

--- a/gptables/test/benchmark_write_performance.py
+++ b/gptables/test/benchmark_write_performance.py
@@ -1,0 +1,147 @@
+"""
+Benchmark script to scope writing-time performance of gptables for tables of
+varying sizes.
+
+Usage:
+    python -m gptables.test.benchmark_write_performance
+    python -m gptables.test.benchmark_write_performance --profile
+"""
+
+import argparse
+import cProfile
+import io
+import pstats
+import tempfile
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+import gptables as gpt
+
+# Table sizes to test: (rows, cols)
+SIZES = [
+    (10, 5),
+    (50, 5),
+    (100, 5),
+    (100, 20),
+    (500, 10),
+    (1000, 10),
+    (1000, 30),
+    (5000, 10),
+    (10000, 10),
+    (10000, 20),
+    (20000, 10),
+    (50000, 10),
+    (100000, 10),
+]
+
+
+def _make_table(rows: int, cols: int) -> pd.DataFrame:
+    """Generate a numeric DataFrame of the given shape with a string index column."""
+    rng = np.random.default_rng(42)
+    data = {
+        f"col_{i}": rng.integers(0, 1000, size=rows).astype(float)
+        for i in range(cols - 1)
+    }
+    data = {"category": [f"row_{r}" for r in range(rows)], **data}
+    return pd.DataFrame(data)
+
+
+def _write_once(rows: int, cols: int, tmp_path: Path) -> float:
+    """Write a single GPTable workbook and return elapsed seconds."""
+    table = _make_table(rows, cols)
+    gptable = gpt.GPTable(
+        table=table,
+        table_name=f"benchmark_{rows}x{cols}",
+        title=f"Benchmark table ({rows} rows x {cols} cols)",
+        scope="Benchmark",
+        source="Generated data",
+        index_columns={1: 0},
+    )
+    sheets = {"Sheet1": gptable}
+    outfile = tmp_path / f"benchmark_{rows}x{cols}.xlsx"
+
+    t0 = time.perf_counter()
+    wb = gpt.produce_workbook(filename=str(outfile), sheets=sheets)
+    wb.close()
+    return time.perf_counter() - t0
+
+
+def run_benchmarks(repeats: int = 3) -> None:
+    print(
+        f"\n{'Rows':>6}  {'Cols':>6}  {'Cells':>8}  {'Mean (s)':>10}  {'Min (s)':>10}  {'Max (s)':>10}"
+    )
+    print("-" * 60)
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        for rows, cols in SIZES:
+            times = []
+            for _ in range(repeats):
+                elapsed = _write_once(rows, cols, tmp_path)
+                times.append(elapsed)
+            cells = rows * cols
+            mean_t = sum(times) / len(times)
+            print(
+                f"{rows:>6}  {cols:>6}  {cells:>8}  {mean_t:>10.3f}  {min(times):>10.3f}  {max(times):>10.3f}"
+            )
+    print()
+
+
+def run_profile(rows: int = 1000, cols: int = 10) -> None:
+    """Profile a single write of the given size and print the top hotspots."""
+    print(f"\nProfiling write of {rows}x{cols} table ...\n")
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        table = _make_table(rows, cols)
+        gptable = gpt.GPTable(
+            table=table,
+            table_name="profile_table",
+            title="Profile table",
+            scope="Benchmark",
+            source="Generated data",
+            index_columns={1: 0},
+        )
+        sheets = {"Sheet1": gptable}
+        outfile = tmp_path / "profile.xlsx"
+
+        pr = cProfile.Profile()
+        pr.enable()
+        wb = gpt.produce_workbook(filename=str(outfile), sheets=sheets)
+        wb.close()
+        pr.disable()
+
+    stream = io.StringIO()
+    ps = pstats.Stats(pr, stream=stream).sort_stats("cumulative")
+    ps.print_stats(30)
+    print(stream.getvalue())
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="gptables write-performance benchmark")
+    parser.add_argument(
+        "--profile",
+        action="store_true",
+        help="Run cProfile on a 1000x10 table instead of the size sweep",
+    )
+    parser.add_argument(
+        "--profile-size",
+        nargs=2,
+        type=int,
+        metavar=("ROWS", "COLS"),
+        default=[1000, 10],
+        help="Table size to profile (default: 1000 10)",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=3,
+        help="Number of repeats per size for the benchmark sweep (default: 3)",
+    )
+    args = parser.parse_args()
+
+    if args.profile:
+        run_profile(*args.profile_size)
+    else:
+        run_benchmarks(repeats=args.repeats)


### PR DESCRIPTION
### Proposed Changes
  - Add benchmark_write_performance.py to measure how long gptables takes to write Excel workbooks for different table sizes.
  - Implement efficiencies by swapping pandas cell-by-cell access for plain Python lists and by caching XlsxWriter format objects.

### Related Issues
  - Related to https://github.com/ONSdigital/gptables/issues/278


### Pre-requisites
This section may not be fully required if the branch is not merging into main.
Please indicate items that aren't necessary and why, with comments around incomplete checks.

- [ ] Version number has been incremented, according to [SemVer][semver]
- [ ] Changelog has been updated, listing changes to this version. Use the [keep a changelog][changelog] format
- [ ] New features are tested
- [ ] New features follow the Analysis Function Releasing statistics in spreadsheets [guidance][guidance]
- [ ] New features are documented using the [numpydoc][numpy-docstrings] docstring format
- [ ] Other relevant package documentation is updated
- [ ] For new functionality, examples are included in the docs or a [feature request][feature-request] has
been made for it/them
- [ ] Required workflows and pre-commits succeed

[changelog]: [https://keepachangelog.com/en/1.0.0/]
[feature-request]: [https://github.com/best-practice-and-impact/gptables/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=]
[guidance]: https://analysisfunction.civilservice.gov.uk/policy-store/releasing-statistics-in-spreadsheets/
[numpy-docstrings]: [https://numpydoc.readthedocs.io/en/latest/format.html]
[semver]: [https://semver.org/spec/v2.0.0.html]
