### PR TITLE
add different ways to format headers

### DIFF
--- a/docs/how_to/additional_formatting.md
+++ b/docs/how_to/additional_formatting.md
@@ -11,19 +11,21 @@ with the `gptable.GPTable(..., additional_formatting = ...)` parameter. See the 
     Refer to the Releasing statistics in spreadsheets [guidance](https://analysisfunction.civilservice.gov.uk/policy-store/releasing-statistics-in-spreadsheets/) and consider user needs
     regarding accessiblity before adjusting the formatting.
 
+    If you use coloured text, do not rely on colour alone to convey meaning. Important distinctions should still be understandable through the text itself, symbols, notes, or labels, and the spreadsheet should remain understandable in black and white or when read by assistive technology.
+
 The sample code can be run from thes
 [examples](https://github.com/ONSdigital/gptables/tree/main/gptables/examples) folder.
 
 ## Using `additional_formatting`
 
 The `gptable.GPTable(..., additional_formatting = ...)` parameter allows for specifying
-columns, rows, and/or cells and the corresponding formatting changes to make.
+columns, rows, cells, and selected header parts and the corresponding formatting changes to make.
 
 !!! warning "Formatting conflicts"
     There are some conflicts between additional formatting options, for example wrapping
     and shrinking text. Outputs should be reviewed for correctness.
 
-The option of what to format is specified, followed by the specific columns, rows, or cells,
+The option of what to format is specified, followed by the specific columns, rows, cells, or header parts,
 and then the formatting changes. To change the properties of columns called Species and Island
 to be center-aligned and italic, for example:
 
@@ -43,36 +45,55 @@ sample_additional_formatting = [
 Columns can be referenced by name or number. Rows may only be referenced by number, with `-1`
 corresponding to the last row. Column and row numbers include indices and column headings. Numeric indexing refers to position within the table, not the position in the output Excel sheet. Cell formatting takes highest precedence, followed by row formatting, and finally column formatting.
 
-Multiple selections of columns, rows, and cells can be made in a single `additional_formatting` list.
+Header formatting uses a `header` entry with:
+
+- `columns`: a list of column names and/or 0-indexed column positions
+- `target`: one of `name`, `units`, or `note`
+- `format`: a dictionary of valid XlsxWriter format properties
+
+This makes it possible to format the visible column name, the units line, and the note marker separately within the same header cell.
+
+Multiple selections of columns, rows, cells, and header parts can be made in a single `additional_formatting` list.
 
 ```python
 penguins_additional_formatting = [
     {
-        "column": {
-            "columns": ["Species", "Island"],
+        "header": {
+            "columns": ["Species"],
+            "target": "name",
             "format": {
-                "align": "center",
+                "bold": True,
+                "font_color": "#0000FF",
+            },
+        }
+    },
+    {
+        "header": {
+            "columns": [3],
+            "target": "units",
+            "format": {
                 "italic": True,
             },
         }
     },
     {
-        "column": {"columns": [3], "format": {"left": 1}}
-    },
-    {
-        "row": {
-            "rows": -1,
+        "header": {
+            "columns": ["Body Mass (g)"],
+            "target": "note",
             "format": {
-                "bottom": 1,
-                "indent": 2,
+                "font_color": "#B30000",
             },
         }
     },
 ]
 ```
 
-This is combined with a basic example below in an extendable tab. The result is
-italicisation of two columns, left bordering on the 4th column, and indentation in the final row.
+This focused example shows all of the new header-targeting behaviour in one place:
+
+- formatting a specific header name
+- formatting units differently
+- formatting a note marker differently
+- targeting columns by both name and index
 
 ??? "Using additional formatting"
     ```python
@@ -83,23 +104,30 @@ italicisation of two columns, left bordering on the 4th column, and indentation 
 
     penguins_additional_formatting = [
         {
-            "column": {
-                "columns": ["Species", "Island"],
+            "header": {
+                "columns": ["Species"],
+                "target": "name",
                 "format": {
-                    "align": "center",
+                    "bold": True,
+                    "font_color": "#0000FF",
+                },
+            }
+        },
+        {
+            "header": {
+                "columns": [3],
+                "target": "units",
+                "format": {
                     "italic": True,
                 },
             }
         },
         {
-            "column": {"columns": [3], "format": {"left": 1}}
-        },
-        {
-            "row": {
-                "rows": -1,
+            "header": {
+                "columns": ["Body Mass (g)"],
+                "target": "note",
                 "format": {
-                    "bottom": 1,
-                    "indent": 2,
+                    "font_color": "#B30000",
                 },
             }
         },
@@ -113,6 +141,8 @@ italicisation of two columns, left bordering on the 4th column, and indentation 
                     "This is another subtitle"],
         scope = "Penguins",
         source = "Palmer Station, Antarctica",
+        units = {3: "mm", "Body Mass (g)": "grams"},
+        table_notes = {"Body Mass (g)": "$$body_mass_note$$"},
         additional_formatting = penguins_additional_formatting,
     )
 
@@ -124,6 +154,10 @@ italicisation of two columns, left bordering on the 4th column, and indentation 
     )
     wb.close()
     ```
+
+For example, the first entry targets the `Species` column by name and formats the header text itself. The second targets the fourth column by index and applies formatting only to the units line. The third targets the `Body Mass (g)` column by name and formats only the rendered note marker.
+
+The example uses blue `#0000FF` and red `#B30000`, which are listed in the guidance as accessible text colours on a no-fill background. Even so, the colour is only decorative here: the note marker remains visible as text, and the header text remains understandable without colour.
 
 ![](../static/howto_additional_formatting.png)
 

--- a/gptables/core/gptable.py
+++ b/gptables/core/gptable.py
@@ -71,6 +71,7 @@ class GPTable:
         self.table_notes = None  # str or {units (str):column index (int)} dict
 
         self._VALID_INDEX_LEVELS = [1, 2, 3]
+        self._VALID_HEADER_FORMAT_TARGETS = ["name", "units", "note"]
         self.index_levels = 0
         self.index_columns = {}  # {index level (int): column index (int)}
         self._column_headings = set()  # Non-index column headings
@@ -408,6 +409,72 @@ class GPTable:
 
         self.units = new_units
 
+    def _resolve_column_identifier(self, column_id: Any) -> int:
+        """
+        Resolve a column name or integer position to a current column index.
+        """
+        if isinstance(column_id, int):
+            if not self._valid_column_index(column_id):
+                raise ValueError(
+                    "Out of range - column identifier must be a valid, 0-indexed column number"
+                )
+            return column_id
+
+        try:
+            return self.table.columns.get_loc(column_id)
+        except KeyError:
+            base_headers = [str(header).split("\n")[0] for header in self.table.columns]
+            if column_id in base_headers:
+                return base_headers.index(column_id)
+            raise ValueError(f"Column `{column_id}` not found in table")
+
+    def _get_units_by_column_index(self) -> Dict[int, Any]:
+        """
+        Normalise the units mapping to current integer column indexes.
+        """
+        if not isinstance(self.units, dict):
+            return {}
+
+        return {
+            self._resolve_column_identifier(column_id): unit_text
+            for column_id, unit_text in self.units.items()
+        }
+
+    def _get_table_notes_by_column_index(self) -> Dict[int, Any]:
+        """
+        Normalise the table notes mapping to current integer column indexes.
+        """
+        if not isinstance(self.table_notes, dict):
+            return {}
+
+        return {
+            self._resolve_column_identifier(column_id): note_text
+            for column_id, note_text in self.table_notes.items()
+        }
+
+    def get_header_parts(self, column_index: int) -> Dict[str, Any]:
+        """
+        Return the displayable header parts for a given column.
+        """
+        header = self.table.columns[column_index]
+        units_by_index = self._get_units_by_column_index()
+        notes_by_index = self._get_table_notes_by_column_index()
+
+        name = header
+        unit_text = units_by_index.get(column_index)
+
+        if unit_text is not None and isinstance(header, str):
+            suffix = f"({unit_text})"
+            lines = header.splitlines()
+            if lines and lines[-1] == suffix:
+                name = "\n".join(lines[:-1]) or lines[0]
+
+        return {
+            "name": name,
+            "units": unit_text,
+            "note": notes_by_index.get(column_index),
+        }
+
     def _update_column_names_in_additional_formatting(
         self, col_names: Dict[Any, Any]
     ) -> None:
@@ -607,16 +674,52 @@ class GPTable:
             raise TypeError(msg)
         keys = [key for item in new_formatting for key in item.keys()]
         for key in keys:
-            if key not in ["column", "row", "cell"]:
+            if key not in ["column", "row", "cell", "header"]:
                 msg = (
                     f"`{key}` is not a supported format type. Please use"
-                    " `column`, `row` or `cell`"
+                    " `column`, `row`, `cell` or `header`"
                 )
                 raise ValueError(msg)
 
         self._validate_format_labels(new_formatting)
+        self._validate_header_formatting(new_formatting)
 
         self.additional_formatting = new_formatting
+
+    def _validate_header_formatting(self, format_list: List[Dict[str, Any]]) -> None:
+        """
+        Validate any header-specific formatting descriptors.
+        """
+        for item in format_list:
+            if "header" not in item:
+                continue
+
+            header_desc = item["header"]
+            if not isinstance(header_desc, dict):
+                raise TypeError("`header` formatting must be provided as a dictionary")
+
+            required_keys = {"columns", "target", "format"}
+            missing_keys = required_keys - set(header_desc.keys())
+            if missing_keys:
+                missing = "`, `".join(sorted(missing_keys))
+                raise ValueError(
+                    f"`header` formatting is missing required keys: `{missing}`"
+                )
+
+            columns = header_desc["columns"]
+            if not isinstance(columns, list) or len(columns) == 0:
+                raise TypeError("`header.columns` must be a non-empty list")
+
+            target = header_desc["target"]
+            if target not in self._VALID_HEADER_FORMAT_TARGETS:
+                valid_targets = "`, `".join(self._VALID_HEADER_FORMAT_TARGETS)
+                raise ValueError(
+                    f"`{target}` is not a supported header formatting target. "
+                    f"Please use `{valid_targets}`"
+                )
+
+            if not isinstance(header_desc["format"], dict):
+                raise TypeError("`header.format` must be provided as a dictionary")
 
     def _validate_format_labels(self, format_list: List[Dict[str, Any]]) -> None:
         """

--- a/gptables/core/wrappers.py
+++ b/gptables/core/wrappers.py
@@ -566,7 +566,7 @@ class GPWorksheet(Worksheet):
             self._set_column_widths(widths)
 
         if not any(isinstance(header, FormatList) for header in header_row):
-            self._mark_data_as_worksheet_table(gptable, formats)
+            self._mark_data_as_worksheet_table(gptable, formats, header_row)
 
         return pos
 
@@ -792,7 +792,10 @@ class GPWorksheet(Worksheet):
         return pos
 
     def _mark_data_as_worksheet_table(
-        self, gptable: "GPTable", formats_dataframe: pd.DataFrame
+        self,
+        gptable: "GPTable",
+        formats_dataframe: pd.DataFrame,
+        header_row: list = None,
     ) -> None:
         """
         Marks the data to be recognised as a Worksheet Table in Excel.
@@ -807,7 +810,10 @@ class GPWorksheet(Worksheet):
         """
         data_range = gptable.data_range
 
-        column_list = gptable.table.columns.tolist()
+        if header_row is None:
+            column_list = gptable.table.columns.tolist()
+        else:
+            column_list = header_row
         formats_list = [
             self._workbook.add_format(format_dict)
             for format_dict in formats_dataframe.iloc[0, :].tolist()

--- a/gptables/core/wrappers.py
+++ b/gptables/core/wrappers.py
@@ -160,31 +160,16 @@ class GPWorksheet(Worksheet):
         """
         Reference annotations in the table column headings and index columns.
         """
-        table = gptable.table.copy()
-
         notes = getattr(gptable, "table_notes", {}) or {}
         if notes:
-            headers = list(table.columns)
-            rename_map = {}
-
+            rendered_notes = {}
             for key, note_token in notes.items():
-
-                idx = key if isinstance(key, int) else table.columns.get_loc(key)
-                old = headers[idx]
-
                 rendered = self._replace_reference_in_attr(note_token, reference_order)
-
-                if not (
-                    isinstance(old, str)
-                    and old.splitlines()
-                    and old.splitlines()[-1] == rendered
-                ):
-                    new = f"{old}\n{rendered}"
-                    rename_map[old] = new
-            if rename_map:
-                table = table.rename(columns=rename_map)
+                rendered_notes[key] = rendered
+            gptable.table_notes = rendered_notes
 
         index_columns = gptable.index_columns.values()
+        table = gptable.table.copy()
         for col in index_columns:
             table.iloc[:, col] = table.iloc[:, col].apply(
                 lambda x: self._replace_reference_in_attr(x, reference_order)
@@ -528,8 +513,13 @@ class GPWorksheet(Worksheet):
         index_columns = [col for col in gptable.index_columns.values()]
         data = pd.DataFrame(gptable.table, copy=True)
 
+        header_formatting, table_formatting = self._split_header_formatting(
+            gptable.additional_formatting
+        )
+
         # Create row containing column headings
-        data.loc[-1] = data.columns
+        header_row = self._build_header_row(gptable, header_formatting)
+        data.loc[-1] = header_row
         data.index = data.index + 1
         data.sort_index(inplace=True)
 
@@ -564,7 +554,7 @@ class GPWorksheet(Worksheet):
 
         # Add additional table-specific formatting from GPTable
         self._apply_additional_formatting(
-            formats, gptable.additional_formatting, gptable.index_levels
+            formats, table_formatting, gptable.index_levels
         )
 
         # Write table
@@ -575,9 +565,95 @@ class GPWorksheet(Worksheet):
             widths = self._calculate_column_widths(data, formats)
             self._set_column_widths(widths)
 
-        self._mark_data_as_worksheet_table(gptable, formats)
+        if not any(isinstance(header, FormatList) for header in header_row):
+            self._mark_data_as_worksheet_table(gptable, formats)
 
         return pos
+
+    @staticmethod
+    def _split_header_formatting(additional_formatting: list) -> tuple:
+        """
+        Separate header rich text formatting from cell-level formatting.
+        """
+        header_formatting = []
+        table_formatting = []
+
+        for item in additional_formatting:
+            if "header" in item:
+                header_formatting.append(item["header"])
+            else:
+                table_formatting.append(item)
+
+        return header_formatting, table_formatting
+
+    def _build_header_row(self, gptable: "GPTable", header_formatting: list) -> list:
+        """
+        Build rendered header values from name, units and note parts.
+        """
+        header_format_map = self._group_header_formatting(gptable, header_formatting)
+        header_row = []
+
+        for column_index in range(gptable.table.shape[1]):
+            parts = gptable.get_header_parts(column_index)
+            part_formats = header_format_map.get(column_index, {})
+            header_row.append(self._compose_header_text(parts, part_formats))
+
+        return header_row
+
+    @staticmethod
+    def _compose_header_text(parts: dict, part_formats: dict) -> object:
+        """
+        Combine header parts into a plain string or rich text value.
+        """
+        rendered_parts = []
+
+        name = parts.get("name")
+        units = parts.get("units")
+        note = parts.get("note")
+
+        if name not in [None, ""]:
+            rendered_parts.append((name, part_formats.get("name")))
+        if units not in [None, ""]:
+            rendered_parts.append((f"({units})", part_formats.get("units")))
+        if note not in [None, ""]:
+            rendered_parts.append((note, part_formats.get("note")))
+
+        if not any(fmt for _, fmt in rendered_parts):
+            return "\n".join(str(text) for text, _ in rendered_parts)
+
+        rich_items = []
+        for index, (text, fmt) in enumerate(rendered_parts):
+            text = str(text)
+            if index > 0:
+                text = "\n" + text
+
+            if fmt:
+                rich_items.extend([fmt, text])
+            else:
+                rich_items.append(text)
+
+        return FormatList(rich_items)
+
+    @staticmethod
+    def _group_header_formatting(gptable: "GPTable", header_formatting: list) -> dict:
+        """
+        Group header formatting descriptors by column index and target part.
+        """
+        grouped = {}
+
+        for format_desc in header_formatting:
+            target = format_desc["target"]
+            formatting = format_desc["format"]
+            for column_id in format_desc["columns"]:
+                column_index = gptable._resolve_column_identifier(column_id)
+                if column_index not in grouped:
+                    grouped[column_index] = {}
+
+                current_format = grouped[column_index].get(target, {}).copy()
+                current_format.update(formatting)
+                grouped[column_index][target] = current_format
+
+        return grouped
 
     def _apply_column_alignments(
         self, data_table: pd.DataFrame, formats_table: pd.DataFrame, index_columns: list

--- a/gptables/examples/howto_additional_formatting.py
+++ b/gptables/examples/howto_additional_formatting.py
@@ -14,21 +14,30 @@ formatted_subtitles = [
 
 sample_additional_formatting = [
     {
-        "column": {
-            "columns": ["Species", "Island"],
+        "header": {
+            "columns": ["Species"],
+            "target": "name",
             "format": {
-                "align": "center",
+                "bold": True,
+                "font_color": "#0000FF",
+            },
+        }
+    },
+    {
+        "header": {
+            "columns": [3],
+            "target": "units",
+            "format": {
                 "italic": True,
             },
         }
     },
-    {"column": {"columns": [3], "format": {"left": 1}}},
     {
-        "row": {
-            "rows": -1,
+        "header": {
+            "columns": ["Body Mass (g)"],
+            "target": "note",
             "format": {
-                "bottom": 1,
-                "indent": 2,
+                "font_color": "#B30000",
             },
         }
     },
@@ -41,6 +50,8 @@ penguins_table = gpt.GPTable(
     subtitles=formatted_subtitles,
     scope="Penguins",
     source="Palmer Station, Antarctica",
+    units={3: "mm", "Body Mass (g)": "grams"},
+    table_notes={"Body Mass (g)": "$$body_mass_note$$"},
     additional_formatting=sample_additional_formatting,
 )
 

--- a/gptables/test/test_gptable.py
+++ b/gptables/test/test_gptable.py
@@ -367,6 +367,43 @@ class TestAttrValidationGPTable:
         )
         assert getattr(gptable, "additional_formatting") == additional_formatting
 
+    def test_valid_header_additional_formatting(self, create_gptable_with_kwargs):
+        additional_formatting = [
+            {
+                "header": {
+                    "columns": ["columnA"],
+                    "target": "units",
+                    "format": {"italic": True},
+                }
+            }
+        ]
+
+        gptable = create_gptable_with_kwargs(
+            {
+                "table": pd.DataFrame(columns=["columnA"]),
+                "additional_formatting": additional_formatting,
+            }
+        )
+
+        assert gptable.additional_formatting == additional_formatting
+
+    def test_invalid_header_additional_format_target(self, create_gptable_with_kwargs):
+        with pytest.raises(ValueError):
+            create_gptable_with_kwargs(
+                {
+                    "table": pd.DataFrame(columns=["columnA"]),
+                    "additional_formatting": [
+                        {
+                            "header": {
+                                "columns": ["columnA"],
+                                "target": "invalid",
+                                "format": {"italic": True},
+                            }
+                        }
+                    ],
+                }
+            )
+
     @pytest.mark.parametrize("unit_text", valid_text_elements_excl_none)
     @pytest.mark.parametrize("column_id", ["columnA", 0])
     def test_units_placement(self, unit_text, column_id, create_gptable_with_kwargs):

--- a/gptables/test/test_wrappers.py
+++ b/gptables/test/test_wrappers.py
@@ -505,6 +505,22 @@ class TestGPWorksheetTable:
         )
         assert len(testbook.ws.tables) == 0
 
+    def test_write_gptable_keeps_plain_header_notes_in_table_definition(
+        self, testbook, create_gptable_with_kwargs
+    ):
+        gptable = create_gptable_with_kwargs(
+            {
+                "table": pd.DataFrame({"columnA": [1], "columnB": [2]}),
+                "units": {"columnB": "unit"},
+                "table_notes": {"columnB": "$$ref$$"},
+            }
+        )
+
+        testbook.ws.write_gptable(gptable, auto_width=True, reference_order=["ref"])
+
+        table = testbook.ws.tables[0]
+        assert table["columns"][1]["name"] == "columnB\n(unit)\n[note 1]"
+
     @pytest.mark.parametrize(
         "data,format,exp_width",
         [

--- a/gptables/test/test_wrappers.py
+++ b/gptables/test/test_wrappers.py
@@ -465,6 +465,46 @@ class TestGPWorksheetTable:
         exp_table_range = xlsxwriter.utility.xl_range(8, 0, 10, 1)
         assert got_table_range == exp_table_range
 
+    def test_write_gptable_supports_header_part_formatting(
+        self, testbook, create_gptable_with_kwargs
+    ):
+        gptable = create_gptable_with_kwargs(
+            {
+                "table": pd.DataFrame({"columnA": [1], "columnB": [2]}),
+                "units": {"columnA": "unit"},
+                "table_notes": {"columnA": "$$ref$$"},
+                "additional_formatting": [
+                    {
+                        "header": {
+                            "columns": ["columnA"],
+                            "target": "units",
+                            "format": {"italic": True},
+                        }
+                    },
+                    {
+                        "header": {
+                            "columns": ["columnA"],
+                            "target": "note",
+                            "format": {"font_color": "red"},
+                        }
+                    },
+                ],
+            }
+        )
+
+        testbook.ws.write_gptable(gptable, auto_width=True, reference_order=["ref"])
+
+        header_row = gptable.data_range[0]
+        cell = testbook.ws.table[header_row][0]
+        assert isinstance(cell[0], int)
+
+        rich_strings = list(testbook.ws.str_table.string_table.keys())
+        assert any("(unit)" in value and "<i/>" in value for value in rich_strings)
+        assert any(
+            "[note 1]" in value and "FFFF0000" in value for value in rich_strings
+        )
+        assert len(testbook.ws.tables) == 0
+
     @pytest.mark.parametrize(
         "data,format,exp_width",
         [


### PR DESCRIPTION
### Proposed Changes
- Added support for formatting individual column headers differently.
- Added support for formatting the units, text or note marker separately within a column header.
- Updated the additional_formatting example and documentation to demonstrate the new header-formatting options.

### Related Issues
  - Related to https://github.com/ONSdigital/gptables/issues/193

### Pre-requisites
This section may not be fully required if the branch is not merging into main.
Please indicate items that aren't necessary and why, with comments around incomplete checks.

- [ ] Version number has been incremented, according to [SemVer][semver]
- [ ] Changelog has been updated, listing changes to this version. Use the [keep a changelog][changelog] format
- [ ] New features are tested
- [ ] New features follow the Analysis Function Releasing statistics in spreadsheets [guidance][guidance]
- [ ] New features are documented using the [numpydoc][numpy-docstrings] docstring format
- [ ] Other relevant package documentation is updated
- [ ] For new functionality, examples are included in the docs or a [feature request][feature-request] has
been made for it/them
- [ ] Required workflows and pre-commits succeed

[changelog]: [https://keepachangelog.com/en/1.0.0/]
[feature-request]: [https://github.com/best-practice-and-impact/gptables/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=]
[guidance]: https://analysisfunction.civilservice.gov.uk/policy-store/releasing-statistics-in-spreadsheets/
[numpy-docstrings]: [https://numpydoc.readthedocs.io/en/latest/format.html]
[semver]: [https://semver.org/spec/v2.0.0.html]
